### PR TITLE
Add variable to control the font size of scope names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# oauth2-scope-selector
+[![Published on NPM](https://img.shields.io/npm/v/@advanced-rest-client/oauth2-scope-selector.svg)](https://www.npmjs.com/package/@advanced-rest-client/oauth2-scope-selector)
+
+[![Tests and publishing](https://github.com/advanced-rest-client/oauth2-scope-selector/actions/workflows/deployment.yml/badge.svg)](https://github.com/advanced-rest-client/oauth2-scope-selector/actions/workflows/deployment.yml)
+
+# &lt;oauth2-scope-selector&gt;
 
 Form element that provides the UI to enter a scope for OAuth 2.0 settings.
 
 ```html
 <oauth2-scope-selector name="scope" allowedscopes='["email", "profile"]'></oauth2-scope-selector>
 ```
-
-[![Published on NPM](https://img.shields.io/npm/v/@advanced-rest-client/oauth2-scope-selector.svg)](https://www.npmjs.com/package/@advanced-rest-client/oauth2-scope-selector)
-
-[![Tests and publishing](https://github.com/advanced-rest-client/oauth2-scope-selector/actions/workflows/deployment.yml/badge.svg)](https://github.com/advanced-rest-client/oauth2-scope-selector/actions/workflows/deployment.yml)
 
 ## Usage
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -42,7 +42,7 @@ anypoint-autocomplete {
 
 .scope-display {
   overflow: hidden;
-  font-size: 16px;
+  font-size: var(--oauth2-scope-selector-font-size, 16px);
 }
 
 .scope-item[data-two-line] {


### PR DESCRIPTION
Default setting overrides global if one wants to use 14px font instead of 16px font. Add the `--oauth2-scope-selector-font-size` to control the font size of the scope names.